### PR TITLE
fix: ensure float/double JSON output always includes decimal point

### DIFF
--- a/src/builder/BuilderJson.cpp
+++ b/src/builder/BuilderJson.cpp
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with OpenLogReplicator; see the file LICENSE;  If not see
 <http://www.gnu.org/licenses/>.  */
 
+#include <cmath>
+
 #include "../common/DbTable.h"
 #include "../common/types/RowId.h"
 #include "../metadata/Metadata.h"
@@ -35,7 +37,10 @@ namespace OpenLogReplicator {
 
         std::ostringstream ss;
         ss << std::setprecision(9) << value;
-        append(ss.str());
+        std::string str = ss.str();
+        if (std::isfinite(value) && str.find('.') == std::string::npos && str.find('e') == std::string::npos)
+            str += ".0";
+        append(str);
     }
 
     void BuilderJson::columnDouble(const std::string& columnName, long double value) {
@@ -46,7 +51,10 @@ namespace OpenLogReplicator {
 
         std::ostringstream ss;
         ss << std::setprecision(17) << value;
-        append(ss.str());
+        std::string str = ss.str();
+        if (std::isfinite(value) && str.find('.') == std::string::npos && str.find('e') == std::string::npos)
+            str += ".0";
+        append(str);
     }
 
     void BuilderJson::columnString(const std::string& columnName) {


### PR DESCRIPTION
## Summary

- Whole-number float values (e.g., `256`) were serialized without a decimal point, causing Debezium's OLR adapter to fail with `DataException: Invalid Java object for schema with type FLOAT32: class java.lang.Double`
- Append `.0` to float/double JSON output when the string has no decimal point or scientific notation
- Workaround for [debezium/dbz#1679](https://github.com/debezium/dbz/issues/1679)

## Test plan

- [x] `make test-redo` — 42/42 pass (excludes enterprise-19 which needs CI regeneration)
- [x] Debezium twin-test `number-precision` — `COL_FLOAT` diffs resolved (remaining diffs are Issue C: NUMBER precision)
- [x] Debezium twin-test full suite — 15/16 pass (lob-operations pre-existing)
- [x] CI: enterprise-19 golden files need regeneration via `sql-tests` workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization of floating-point numbers so whole-number values are emitted with explicit decimal notation (e.g., "1.0" instead of "1"). This prevents integers from being mistaken for integers in contexts expecting floats and improves compatibility when exporting numeric data that requires floating-point representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->