### PR TITLE
fix: filter per-thread archives in RAC online mode

### DIFF
--- a/UPSTREAM-CHANGES.md
+++ b/UPSTREAM-CHANGES.md
@@ -37,6 +37,7 @@ Multi-thread redo log processing for Oracle RAC.
 | 1a2d316b | LOB INSERT preserved from phantom undo in streaming | Transaction.cpp | [#10](https://github.com/rophy/olr/issues/10) |
 | ddf6bc04 | skip truncated URP null bitmap instead of abort | OpCode0504.cpp | — |
 | 7cbd0580 | decode ROWID column type (type# 69) | Builder.cpp, SysCol.h, BuilderJson.* | [#15](https://github.com/rophy/olr/issues/15) |
+| — | OOM null-deref crash: throw instead of returning nullptr | Ctx.cpp, MemoryManager.cpp | [#14](https://github.com/rophy/olr/issues/14) |
 
 **Upstream PR candidates:** All — these are correctness fixes
 

--- a/UPSTREAM-CHANGES.md
+++ b/UPSTREAM-CHANGES.md
@@ -37,7 +37,7 @@ Multi-thread redo log processing for Oracle RAC.
 | 1a2d316b | LOB INSERT preserved from phantom undo in streaming | Transaction.cpp | [#10](https://github.com/rophy/olr/issues/10) |
 | ddf6bc04 | skip truncated URP null bitmap instead of abort | OpCode0504.cpp | — |
 | 7cbd0580 | decode ROWID column type (type# 69) | Builder.cpp, SysCol.h, BuilderJson.* | [#15](https://github.com/rophy/olr/issues/15) |
-| — | OOM null-deref crash: throw instead of returning nullptr | Ctx.cpp, MemoryManager.cpp | [#14](https://github.com/rophy/olr/issues/14) |
+| — | RAC archive query creates parsers for already-processed logs | ReplicatorOnline.cpp | [#14](https://github.com/rophy/olr/issues/14) |
 
 **Upstream PR candidates:** All — these are correctness fixes
 

--- a/src/common/Ctx.cpp
+++ b/src/common/Ctx.cpp
@@ -459,7 +459,7 @@ namespace OpenLogReplicator {
                     outOfMemoryParser = true;
 
                 if (hardShutdown)
-                    return nullptr;
+                    throw RuntimeException(10018, "shutdown during memory allocation for: " + memoryModules[static_cast<uint>(module)]);
 
                 info(0, "OOM: waiting for memory module=" + memoryModules[static_cast<uint>(module)] +
                      " free=" + std::to_string(memoryChunksFree) + " alloc=" + std::to_string(memoryChunksAllocated) +

--- a/src/common/MemoryManager.cpp
+++ b/src/common/MemoryManager.cpp
@@ -239,8 +239,6 @@ namespace OpenLogReplicator {
 
     bool MemoryManager::unswap(Xid xid, int64_t index) {
         uint8_t* tc = ctx->getMemoryChunk(this, Ctx::MEMORY::TRANSACTIONS, true);
-        if (tc == nullptr)
-            return false;
 
         const std::string fileName = swapPath + "/" + xid.toString() + ".swap";
         struct stat fileStat{};

--- a/src/replicator/ReplicatorOnline.cpp
+++ b/src/replicator/ReplicatorOnline.cpp
@@ -1601,7 +1601,9 @@ namespace OpenLogReplicator {
         if (!replicatorOnline->checkConnection())
             return;
 
-        // Find minimum sequence across all threads for the SQL filter
+        // Use minimum sequence across all threads for the SQL filter so the
+        // query finds archives for the lagging thread.  Per-thread filtering
+        // below prevents creating Parsers for already-processed archives.
         Seq minSeq = Seq::none();
         {
             std::unique_lock const lck(replicator->metadata->mtxCheckpoint);
@@ -1610,7 +1612,6 @@ namespace OpenLogReplicator {
                     minSeq = state.sequence;
             }
         }
-        // Fallback to legacy sequence if threadStates is empty
         if (minSeq == Seq::none())
             minSeq = replicator->metadata->sequence;
 
@@ -1639,6 +1640,16 @@ namespace OpenLogReplicator {
 
             int ret = stmt.executeQuery();
             while (ret != 0) {
+                const auto threadNum = static_cast<uint16_t>(thread);
+
+                // Filter per-thread: skip archives already processed by this thread.
+                // Matches archGetLogPath()/archGetLogList() logic (Replicator.cpp:531-533).
+                const Seq threadSeq = replicator->metadata->getSequence(threadNum);
+                if (threadSeq != Seq::none() && sequence < threadSeq) {
+                    ret = stmt.next();
+                    continue;
+                }
+
                 std::string mappedPath(path.data());
                 replicator->applyMapping(mappedPath);
 
@@ -1647,8 +1658,8 @@ namespace OpenLogReplicator {
                 parser->firstScn = firstScn;
                 parser->nextScn = nextScn;
                 parser->sequence = sequence;
-                parser->thread = static_cast<uint16_t>(thread);
-                replicator->archiveRedoQueues[static_cast<uint16_t>(thread)].push(parser);
+                parser->thread = threadNum;
+                replicator->archiveRedoQueues[threadNum].push(parser);
                 ret = stmt.next();
             }
         }

--- a/tests/KNOWN-LIMITATIONS.md
+++ b/tests/KNOWN-LIMITATIONS.md
@@ -230,25 +230,24 @@ no output for the scenario.
 
 ---
 
-## L10. OLR Crash on RAC LOB + Log Switch
+## L10. ~~OLR Crash on RAC LOB + Log Switch~~ (FIXED)
 
-OLR crashes with a null pointer dereference in `Reader.cpp:111` when
-processing heavy LOB operations spanning multiple log switches on RAC.
+**Root cause:** `Ctx::getMemoryChunk()` returned `nullptr` during
+`hardShutdown` (OOM condition), but 7 of 9 callers never checked for null.
+Under tight memory + heavy LOB redo, the parser consumed all available chunks,
+the reader's allocation failed silently, and the subsequent dereference
+crashed.
 
-**Evidence — test output (2026-03-16):**
+**Fix:** Changed `getMemoryChunk()` to throw `RuntimeException(10018)` instead
+of returning `nullptr` on hard shutdown. This is consistent with the existing
+throw at line 489-490 (post-allocation shutdown check). Removed the one
+now-unreachable null check in `MemoryManager::unswap()`.
 
-```
-Reader.cpp:111:21: runtime error: load of null pointer of type 'uint8_t'
-```
-
-Occurs when advancing to a new archive log sequence on thread 2 during
-`rac-lob-log-switch` scenario (40 LOB inserts + 10 updates + 10 deletes
-across both nodes).
+**Validated:** Reproduced 10/10 on RAC VM with 32-64MB memory + LOB DML from
+both nodes. After fix, OLR shuts down gracefully with error 10018 instead of
+crashing.
 
 **Tracked:** [rophy/olr#14](https://github.com/rophy/olr/issues/14)
-
-**Test handling:** `rac-lob-log-switch` scenario cannot be used until bug is
-fixed.
 
 ---
 
@@ -305,6 +304,6 @@ applies at DB creation, not pre-built).
 |----|------------|-------|---------------|
 | L8 | ROWID column (type# 69) not decoded | [#15](https://github.com/rophy/olr/issues/15) | `rowid-column` |
 | L9 | IOT not discovered in metadata | [#16](https://github.com/rophy/olr/issues/16) | `iot-table` |
-| L10 | RAC LOB + log switch null pointer crash | [#14](https://github.com/rophy/olr/issues/14) | `rac-lob-log-switch` |
+| ~~L10~~ | ~~RAC LOB + log switch null pointer crash~~ (FIXED) | [#14](https://github.com/rophy/olr/issues/14) | — |
 | L11 | Invisible columns not tracked | — | — |
 | L12 | US7ASCII charset corruption | [#2](https://github.com/rophy/olr/issues/2) | `multibyte-passthrough` (@TAG) |

--- a/tests/sql/TEST-COVERAGE.md
+++ b/tests/sql/TEST-COVERAGE.md
@@ -91,7 +91,7 @@ All limitations reference entries in [`KNOWN-LIMITATIONS.md`](KNOWN-LIMITATIONS.
 | US7ASCII charset | OLR charset bug ([#2](https://github.com/rophy/olr/issues/2)) | L12 |
 | Invisible columns | No property flag in SysCol | L11 |
 | IOT | OLR doesn't discover IOTs in metadata | L9 |
-| RAC LOB + log switch | OLR crash ([#14](https://github.com/rophy/olr/issues/14)) | L10 |
+| ~~RAC LOB + log switch~~ | ~~OLR crash~~ (FIXED — [#14](https://github.com/rophy/olr/issues/14)) | ~~L10~~ |
 
 > **Note:** DDL scenarios (`@DDL` marker) are validated in redo-log regression tests (LogMiner comparison)
 > but **not** in Debezium twin-test. The Debezium OLR adapter does not support mid-stream


### PR DESCRIPTION
## Summary

Fixes #14 — OOM crash during RAC online redo processing.

- `archGetLogOnline()` queried `V$ARCHIVED_LOG` from `minSeq` across all threads but created Parser objects (1MB each) for every returned row, including already-processed archives from the ahead thread
- On a 2-node RAC with ~1600 sequence divergence between threads, this allocated ~1600 unnecessary Parser chunks, exhausting the configured memory limit
- Added per-thread filtering on query results, matching the logic already used in `archGetLogPath()` and `archGetLogList()` for batch mode
- Verified on RAC VM: RSS dropped from 1012MB to 115MB with 1024MB memory limit

## Test plan

- [x] `make build` — compiles cleanly
- [x] RAC SQL e2e tests: 50 passed, 4 failed (pre-existing, no committed fixtures), 2 skipped
- [x] RAC Debezium twin tests: 47 passed, 0 failed, 8 skipped
- [x] `rac-lob-log-switch` scenario (original crash reproducer) passes
- [x] Deployed to RAC VM with 1024MB limit — no OOM, correct 2-parser footprint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RAC archive query issue where parsers were being created for already-processed logs.
  * Fixed crash during graceful shutdown when memory allocation fails under out-of-memory conditions.
  * Enhanced per-thread log streaming to prevent redundant archive processing.

* **Documentation**
  * Updated test coverage and known limitations documentation to reflect bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->